### PR TITLE
syntax highlight example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### Example
 
-```
+``` js
 // middleware.js
 
 // worker loader is a webpack package that loads the worker for you.
@@ -43,7 +43,7 @@ const secondWorkerMiddleware = newWorkerMiddleware(new secondWorker(), 'SECOND_W
 export default [firstWorkerMiddleware, secondWorkerMiddleware];
 ```
 
-```
+``` js
 // store.js
 
 import { createStore, applyMiddleware } from 'redux';
@@ -59,7 +59,7 @@ const store = createStore(
 export default store;
 ```
 
-```
+``` js
 // action.js
 
 export function activateWorker() {


### PR DESCRIPTION
Hi there,

Just a quick PR to enable syntax highlighting in `README.md` - if disabling highlighting was intentional, just ignore this PR.

Have a nice day!

## Goal

Make readme code examples easier to read

## How to Manually test this.

does not apply

## Background

none

## Issue Tracker

does not apply

## Affirm Completion Criteria

does not apply

## Notice of Secondary Effects

does not apply